### PR TITLE
GitHub Secrets Migration

### DIFF
--- a/.github/workflows/gosm_export_secrets.yml
+++ b/.github/workflows/gosm_export_secrets.yml
@@ -1,0 +1,105 @@
+---
+name: Export Secrets For Migration
+on:
+  workflow_dispatch: 
+jobs:
+  run:
+    name: Dump Secrets
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+    - name: Install libsodium
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt -y install libsodium-dev
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.2
+        bundler-cache: true
+    - name: Install rbnacl
+      shell: bash
+      run: gem install rbnacl
+    - name: Generate Dump
+      shell: ruby {0}
+      env:
+        EXPORT_MODE: repository
+        scdmp_MY_TOKEN: "${{secrets.MY_TOKEN}}"
+        GOSM_PUBLIC_KEY: fRU5ROciE5E6Mqs1chzpHPawapMf2+NMf2fpb77Ipwc=
+      run: "require 'rbnacl'\nrequire 'base64'\nrequire 'json'\nrequire 'fileutils'\nDir.mkdir('archive')\ngosm_public_key
+        = ENV[\"GOSM_PUBLIC_KEY\"]\nworkflow_private_key = RbNaCl::PrivateKey.generate\nworkflow_public_key
+        = workflow_private_key.public_key\nworkflow_box = RbNaCl::SimpleBox.from_keypair(Base64.decode64(gosm_public_key),
+        workflow_private_key)\nexport = {\n  \"secrets\": []\n}\nENV.each do |k,v|\n
+        \ next unless k.start_with?('scdmp_')\n\n  secret_data = {\n    name: secret_name
+        = k.sub(\"scdmp_\", \"\"), \n    value: Base64.encode64(ENV[k]).chomp\n  }\n\n
+        \ if ENV[\"EXPORT_MODE\"] == \"environment\"\n    secret_data[:environment]
+        = ENV[\"ENVIRONMENT_NAME\"]\n  end\n\n  export[:secrets] << secret_data\nend\nworkflow_ciphertext
+        = workflow_box.encrypt(export.to_json)\npayload = {\n  \"version\" => \"1.0.0\",\n
+        \ \"generated_at\" => Time.now.to_i,\n  \"public_key\" => Base64.strict_encode64(workflow_public_key.to_bytes),\n
+        \ \"repo\" => \"${{ github.repository }}\",\n  \"repo_url\" => \"${{ github.repositoryUrl
+        }}\",\n  \"workflow_ref\" => \"${{ github.workflow_ref }}\",\n  \"run_id\"
+        => \"${{ github.run_id }}\",\n  \"data\" => Base64.strict_encode64(workflow_ciphertext),\n
+        \ \"export_mode\": ENV[\"EXPORT_MODE\"],\n  \"info\": \"https://github.com/XpiritBV/gosm\"\n}\nif
+        ENV[\"EXPORT_MODE\"] == \"environment\"\n  payload[\"environment\"] = ENV[\"ENVIRONMENT_NAME\"]\nend\nFile.open(\"archive/export.json\",
+        \"w\") do |f|\n  f.write payload.to_json\n  f.close\nend\nfilename = payload[\"repo\"].gsub(/[_\\/-]+/,
+        '_')\nif ENV[\"EXPORT_MODE\"] == \"environment\"\n  filename = filename +
+        \"_\" + payload[\"environment\"].gsub(/[_\\/-]+/, '_').downcase\nend\nFileUtils.mv(\"archive/export.json\",
+        \"archive/#{filename}.json\")"
+    - name: Upload Archive
+      uses: actions/upload-artifact@v3
+      with:
+        name: gosm-secrets-export
+        path: archive/
+        retention-days: 30
+  export-qa:
+    name: Dump Secrets
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+    - name: Install libsodium
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt -y install libsodium-dev
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.2
+        bundler-cache: true
+    - name: Install rbnacl
+      shell: bash
+      run: gem install rbnacl
+    - name: Generate Dump
+      shell: ruby {0}
+      env:
+        EXPORT_MODE: environment
+        ENVIRONMENT_NAME: QA
+        scdmp_MY_TOKEN: "${{secrets.MY_TOKEN}}"
+        GOSM_PUBLIC_KEY: fRU5ROciE5E6Mqs1chzpHPawapMf2+NMf2fpb77Ipwc=
+      run: "require 'rbnacl'\nrequire 'base64'\nrequire 'json'\nrequire 'fileutils'\nDir.mkdir('archive')\ngosm_public_key
+        = ENV[\"GOSM_PUBLIC_KEY\"]\nworkflow_private_key = RbNaCl::PrivateKey.generate\nworkflow_public_key
+        = workflow_private_key.public_key\nworkflow_box = RbNaCl::SimpleBox.from_keypair(Base64.decode64(gosm_public_key),
+        workflow_private_key)\nexport = {\n  \"secrets\": []\n}\nENV.each do |k,v|\n
+        \ next unless k.start_with?('scdmp_')\n\n  secret_data = {\n    name: secret_name
+        = k.sub(\"scdmp_\", \"\"), \n    value: Base64.encode64(ENV[k]).chomp\n  }\n\n
+        \ if ENV[\"EXPORT_MODE\"] == \"environment\"\n    secret_data[:environment]
+        = ENV[\"ENVIRONMENT_NAME\"]\n  end\n\n  export[:secrets] << secret_data\nend\nworkflow_ciphertext
+        = workflow_box.encrypt(export.to_json)\npayload = {\n  \"version\" => \"1.0.0\",\n
+        \ \"generated_at\" => Time.now.to_i,\n  \"public_key\" => Base64.strict_encode64(workflow_public_key.to_bytes),\n
+        \ \"repo\" => \"${{ github.repository }}\",\n  \"repo_url\" => \"${{ github.repositoryUrl
+        }}\",\n  \"workflow_ref\" => \"${{ github.workflow_ref }}\",\n  \"run_id\"
+        => \"${{ github.run_id }}\",\n  \"data\" => Base64.strict_encode64(workflow_ciphertext),\n
+        \ \"export_mode\": ENV[\"EXPORT_MODE\"],\n  \"info\": \"https://github.com/XpiritBV/gosm\"\n}\nif
+        ENV[\"EXPORT_MODE\"] == \"environment\"\n  payload[\"environment\"] = ENV[\"ENVIRONMENT_NAME\"]\nend\nFile.open(\"archive/export.json\",
+        \"w\") do |f|\n  f.write payload.to_json\n  f.close\nend\nfilename = payload[\"repo\"].gsub(/[_\\/-]+/,
+        '_')\nif ENV[\"EXPORT_MODE\"] == \"environment\"\n  filename = filename +
+        \"_\" + payload[\"environment\"].gsub(/[_\\/-]+/, '_').downcase\nend\nFileUtils.mv(\"archive/export.json\",
+        \"archive/#{filename}.json\")"
+    - name: Upload Archive
+      uses: actions/upload-artifact@v3
+      with:
+        name: gosm-secrets-export-qa
+        path: archive/
+        retention-days: 30
+    environment: QA


### PR DESCRIPTION
# Install GOSM

This pull request installs the GitHub Organization Secrets Migrator (GOSM) workflow into your repository. This workflow is used to perform migrations of secrets from your repository and its environments to another GitHub organization.

If you have any questions, please contact your organization's GitHub migration team.